### PR TITLE
Bug Fixes

### DIFF
--- a/EvolutionaryLearner.py
+++ b/EvolutionaryLearner.py
@@ -45,7 +45,7 @@ ruleWeightFactor = 1
 
 
 # FITNESS FUNCTION FOR AN INDIVIDUAL AFTER ONE SIMULATION RUN/EPISODE
-def rFit(individual, simTime, aggregateVehicleWaitTime):
+def rFit(individual, simTime):
     # If Individual's simulation time is less than the best time, its fitness is the difference between those two values
     if simTime < bestSUMORuntime:
         return simTime - bestSUMORuntime

--- a/PredicateSet.py
+++ b/PredicateSet.py
@@ -731,7 +731,8 @@ def EVDistanceToIntersection_800(distanceToIntersection):
 
 
 #-------------------- EV Approach Direction --------------------#
-def EVApproachingHorizontal(EVLane, horizontalLanes):
+def EVApproachingHorizontal(laneInfo):
+    EVLane, horizontalLanes = laneInfo
     if EVLane is None:
         return False
     elif EVLane in horizontalLanes:
@@ -740,7 +741,8 @@ def EVApproachingHorizontal(EVLane, horizontalLanes):
         return False
 
 
-def EVApproachingVertical(EVLane, verticalLanes):
+def EVApproachingVertical(laneInfo):
+    EVLane, verticalLanes = laneInfo
     if EVLane is None:
         return False
     elif EVLane in verticalLanes:

--- a/ReinforcementLearner.py
+++ b/ReinforcementLearner.py
@@ -31,8 +31,17 @@ def updatedWeight(rule, nextRule, throughputRatio, waitTimeReducedRatio, interse
 
 # Function to determine the reward
 def determineReward(throughputRatio, waitTimeReducedRatio, EVChangeInSpeed, EVChangeInTrafficDensity):
-    return (throughputFactor * throughputRatio) + (waitTimeReducedFactor * waitTimeReducedRatio) + \
-        (EVSpeedFactor * EVChangeInSpeed) + (EVTrafficDensityFactor * EVChangeInTrafficDensity)
+    reward = 0
+
+    reward += throughputFactor * throughputRatio
+    reward += waitTimeReducedFactor * waitTimeReducedRatio
+
+    if EVChangeInSpeed is not None:
+        reward += EVSpeedFactor * EVChangeInSpeed
+    if EVChangeInTrafficDensity is not None:
+        reward += EVTrafficDensityFactor * EVChangeInTrafficDensity
+
+    return reward
 
 
 def determinePenalty(intersectionQueueDifference, EVIsStopped):


### PR DESCRIPTION
- Fixed bug where the EV approach direction predicates took too many parameter. Now the function only takes one parameter and then unpacks it into separate variables.
- Fixed bug where a NoneType leadingEV was attempted to be subscripted. Now only when the leadingEV is not None will the reinforcement learning with EV parameters be performed. The EV reinforcement learning will also not be performed if there was no EV present the previous step.
- Fixed bug where there was a useless parameter in rFit. Removed the parameter.